### PR TITLE
Fix swagger schema generation

### DIFF
--- a/Api/ExceptionsInterface.php
+++ b/Api/ExceptionsInterface.php
@@ -5,7 +5,7 @@ namespace Fsw\ErrorSieve\Api;
 interface ExceptionsInterface
 {
     /**
-     * @return array
+     * @return mixed[]
      */
     public function getStatus();
 }


### PR DESCRIPTION
The schema is broken https://magento.local/rest/all/schema?services=all

```
<message>The "array" class doesn't exist and the namespace must be specified. Verify and try again.</message>
```